### PR TITLE
📝 #56: Denoビルド、プラグイン章の追加

### DIFF
--- a/deno/index.md
+++ b/deno/index.md
@@ -611,7 +611,7 @@ deno run --allow-env --allow-read main.ts
 ## ビルド
 
 Denoのネイティブバンドラである、`deno bundle`はDeno 2.0より非推奨となりました。
-そのため、Denoでは代替として以下のツールの使用が推奨されています。
+そのため、現在は以下のような代替ツールの使用が推奨されています。
 
 - [`deno_emit`](https://github.com/denoland/deno_emit)
 - [`esbuild`](https://esbuild.github.io/)
@@ -619,7 +619,8 @@ Denoのネイティブバンドラである、`deno bundle`はDeno 2.0より非�
 
 ### `deno_emit`
 
-`deno_emit`はDenoが公式で管理する標準ライブラリの一つであり、JavaScriptとTypeScriptをトランスパイル、バンドルするためのAPIです。
+`deno_emit`はDenoが公式で管理する標準ライブラリの一つであり、JavaScriptとTypeScriptをトランスパイル、バンドルするためのAPIを提供します。
+Deno環境に組み込まれた形で動作するため、Deno特有のURLインポートにも対応しています。
 
 ```typescript
 import { bundle } from "jsr:@deno/emit";
@@ -633,13 +634,14 @@ console.log(code);
 Deno.writeTextFile("./build/result.js", code);
 ```
 
-バンドル結果はAPIを通じてオブジェクトとして返されるため、成果物としてファイルを出力したい場合は`Deno.writeTextFile`を使用する必要があります。上記のサンプルコードではバンドル結果を`./build/result.js`に保存しています。
+`deno_emit`のAPIはバンドル結果をオブジェクトとして返すため、必要に応じて`Deno.writeTextFile`などを使ってファイル出力を行います。
+上記のサンプルコードではバンドル結果を`./build/result.js`に保存しています。
 
 ## プラグイン
 
 Denoは現在のところ、ランタイムやバンドラで利用できるプラグインを作成するためのプラグインAPIを提供していません。
 しかし、Denoの柔軟な設計を活かして、いくつかのツールを組み合わせることでプラグイン的な機能を実現できます。
-例えば、バンドラにプラグインを追加したい場合は、`esbuild`の[`esbuild_deno_loader`](https://deno.land/x/esbuild_deno_loader@0.9.0)を利用することでプラグイン機能を作成できます。
+例えば、`esbuild`自体にはカスタムプラグインを作成するAPIが提供されています。これを利用することで、Denoのバンドラに`esbuild`を使用し、さらにDeno特有のモジュール解決をサポートするツールである[`esbuild_deno_loader`](https://deno.land/x/esbuild_deno_loader@0.9.0)を組み合わせることで、Deno環境でもカスタムプラグインを作成することが可能です。
 
 ## テスト
 

--- a/deno/index.md
+++ b/deno/index.md
@@ -610,17 +610,36 @@ deno run --allow-env --allow-read main.ts
 
 ## ビルド
 
-<!-- 各環境向けのビルド方法 -->
+Denoのネイティブバンドラである、`deno bundle`はDeno 2.0より非推奨となりました。
+そのため、Denoでは代替として以下のツールの使用が推奨されています。
 
-### SPA などのブラウザ向け
+- [`deno_emit`](https://github.com/denoland/deno_emit)
+- [`esbuild`](https://esbuild.github.io/)
+- [`rollup`](https://rollupjs.org/)
 
-### Node.js 向け
+### `deno_emit`
 
-### Deno 向け
+`deno_emit`はDenoが公式で管理する標準ライブラリの一つであり、JavaScriptとTypeScriptをトランスパイル、バンドルするためのAPIです。
+
+```typescript
+import { bundle } from "jsr:@deno/emit";
+const result = await bundle(
+  new URL("https://deno.land/std@0.140.0/examples/chat/server.ts"),
+);
+
+const { code } = result;
+console.log(code);
+
+Deno.writeTextFile("./build/result.js", code);
+```
+
+バンドル結果はAPIを通じてオブジェクトとして返されるため、成果物としてファイルを出力したい場合は`Deno.writeTextFile`を使用する必要があります。上記のサンプルコードではバンドル結果を`./build/result.js`に保存しています。
 
 ## プラグイン
 
-<!-- Denoプラグインの書き方 -->
+Denoは現在のところ、ランタイムやバンドラで利用できるプラグインを作成するためのプラグインAPIを提供していません。
+しかし、Denoの柔軟な設計を活かして、いくつかのツールを組み合わせることでプラグイン的な機能を実現できます。
+例えば、バンドラにプラグインを追加したい場合は、`esbuild`の[`esbuild_deno_loader`](https://deno.land/x/esbuild_deno_loader@0.9.0)を利用することでプラグイン機能を作成できます。
 
 ## テスト
 

--- a/deno/migration.md
+++ b/deno/migration.md
@@ -262,6 +262,27 @@ denoは`package.json`内の`scripts`の内容を参照するため、追加の�
 `deno task build`でビルドを実行します。
 開発サーバの起動スクリプトと同様に、ビルドスクリプトにNode.js環境専用の機能が含まれている場合、必要に応じてビルドコマンドを修正してください。
 
+### `script`プロパティ
+
+`package.json`の`script`プロパティに記述された定義は、修正なしで`deno task <script>`で実行できますが、`npm`指定子を付けることでも実行可能です。
+
+例えば、Next.jsのプロジェクトであれば、以下のように`npm`指定子を使った定義に修正できます。
+
+```json:package.json
+"scripts": {
+    "dev": "deno run npm:next dev",
+    "build": "deno run npm:next build",
+    "start": "deno run npm:next start",
+    "lint": "deno run npm:next lint"
+  },
+```
+
+`npm`指定子を使った方法では、`deno run`に対応したオプションを追加することができます。例えば、以下のように細かくセキュリティ設定を制限したり、環境変数定義ファイルを明示的に指定することができます。
+
+```json:package.json
+    "build": "deno run -E -env-file=.env.local npm:next build",
+```
+
 ## Tips
 
 ### シェルスクリプト


### PR DESCRIPTION
### やったこと
- ビルド章の追加
  - `deno bundle`が非推奨になっていたため、`deno_emit`でのビルド方法を記述しました
- マイグレーションのビルド章に追記
- プラグイン章の追加
  - Denoの公式ではプラグイン作成APIは用意されていないため、他のサードパーティーを参照するように誘導
  
  close #56 
  close #59 